### PR TITLE
Remove Beta status and add Disclaimer instead

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -128,7 +128,6 @@ Targeted for system administrators and power users, this site provides comprehen
 
 ::::  
 
-
 :::{note}
  The organization, layout and structure of this site is
  under active development and may change frequently. Feedback is appreciated via the


### PR DESCRIPTION
We currently have a BETA status message on the Instinct Docs site, instinct.docs.amd.com, that may lead customers to think our datacenter software offerings are in BETA and not ready for production. We need to remove or change the wording here to a better and clearer message for our customers. 

Suggesting that we instead have a disclaimer at the bottom of the page instead of labeling our docs site as BETA.