### PR TITLE
Add markdown download button and make llms.txt available

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,8 @@
 """Configuration file for the Sphinx documentation builder."""
 import os
 from sphinx import addnodes
+from pathlib import Path
+import shutil
 
 external_projects_remote_repository = ""
 external_projects_current_project = "dcgpu"
@@ -20,10 +22,12 @@ author = "Advanced Micro Devices, Inc."
 copyright = "Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved."
 
 # Required settings
+html_copy_source = True
 html_theme = "rocm_docs_theme"
 html_theme_options = {
     "flavor": "instinct",
     "link_main_doc": True,
+    "use_download_button": True,
     "nav_secondary_items": {
         "Community": "https://github.com/ROCm/ROCm/discussions",
         "Blogs": "https://rocm.blogs.amd.com/",
@@ -43,5 +47,56 @@ external_toc_path = "./sphinx/_toc.yml"
 
 exclude_patterns = ['.venv']
 
+EXCLUDED_DIRS = {
+    "_build",
+    "_templates",
+    "_static",
+    ".git",
+    ".venv",
+}
+
+def should_skip(path: Path) -> bool:
+    return any(part in EXCLUDED_DIRS for part in path.parts)
+
+
+def generate_combined_markdown(app, exception):
+    if exception:
+        return
+
+    docs_root = Path(app.srcdir)
+
+    output_file = Path(app.outdir) / "llms.txt"
+
+    print(output_file)
+
+    all_files = sorted(docs_root.rglob("*.md"))
+
+    combined = []
+    combined.append("# Combined Documentation\n")
+
+    for doc_file in all_files:
+
+        if should_skip(doc_file):
+            continue
+
+        relative = doc_file.relative_to(docs_root)
+
+        combined.append(f"\n---\n")
+        combined.append(f"\n# {relative}\n")
+
+        try:
+            content = doc_file.read_text(encoding="utf-8")
+            combined.append(content)
+            combined.append("\n")
+
+        except Exception as e:
+            combined.append(f"\n[ERROR reading file: {e}]\n")
+
+    output_file.write_text(
+        "\n".join(combined),
+        encoding="utf-8",
+    )
+
 def setup(app):
     app.add_css_file("css/index.css")
+    app.connect("build-finished", generate_combined_markdown)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,7 +73,6 @@ MARKUP_PREFIXES = (
     ":header-rows:",
     ":alt:",
     "+++",
-    "<",
     "-->",
     "{bdg-",
 )
@@ -90,6 +89,17 @@ _RST_UNDERLINE_RE = re.compile(r"^[=\-~^\"\'#*+]{3,}$")
 
 # Matches RST code block directives (e.g. ".. code-block:: cpp", ".. code:: sh")
 _RST_CODE_BLOCK_RE = re.compile(r"^\.\.\s+(code-block|code|sourcecode)::")
+
+# Matches markdown table separator rows (e.g. "|---|---|", "| :--- | ---: |").
+_MD_TABLE_SEP_RE = re.compile(r"^\|[\s|:\-]+\|$")
+
+# Matches RST directives whose indented body should be discarded (e.g. raw HTML).
+_RST_SKIP_BLOCK_RE = re.compile(r"^\.\.\s+raw::")
+
+# Matches HTML tags (e.g. "<div>", "</p>", "<!--") but NOT RST hyperlink URL
+# continuation lines (e.g. "<https://...>`_").  The negative lookahead excludes
+# URL schemes so that multi-line RST inline hyperlinks are preserved.
+_HTML_TAG_RE = re.compile(r"^<(?!https?://|ftp://|mailto:)[a-zA-Z/!]")
 
 MIN_PROSE_LINES = 10
 
@@ -110,13 +120,24 @@ def is_prose_line(line: str) -> bool:
     # Drop MyST/RST anchor labels (e.g. "(gpu-arch-documentation)=")
     if _ANCHOR_LABEL_RE.match(stripped):
         return False
+    # Drop markdown table separator rows (e.g. "|---|---|", "| :--- | ---: |")
+    if _MD_TABLE_SEP_RE.match(stripped):
+        return False
+    # Drop HTML tags (e.g. "<div>", "</p>") but keep RST hyperlink URL
+    # continuation lines (e.g. "<https://rocm.docs.amd.com/...>`_")
+    if _HTML_TAG_RE.match(stripped):
+        return False
     # Drop RST directives, comments, hyperlink targets, and substitution definitions
     if stripped.startswith(".."):
         return False
-    # Drop RST field list items (e.g. ":type: int") and MyST directive options without
-    # a leading colon (e.g. "align: center"). Excludes inline roles at line start
-    # (e.g. ":cpp:func:`hipMalloc` returns..." or ":ref:`foo <bar>` describes...").
-    if re.match(r"^:[A-Za-z][A-Za-z0-9_-]*:(\s|$)", stripped):
+    # Drop YAML frontmatter key-value pairs (e.g. "description lang=en": "text")
+    if stripped.startswith('"') and re.match(r'^"[^"]+"\s*:', stripped):
+        return False
+    # Drop RST field list items (e.g. ":type: int") and extended RST meta
+    # options (e.g. ":description lang=en: text"). Excludes inline roles at line
+    # start (e.g. ":cpp:func:`hipMalloc` returns..." or ":ref:`foo <bar>` describes...")
+    # because those are followed by a backtick, not a space or end-of-line.
+    if re.match(r"^:[A-Za-z][A-Za-z0-9_ =-]*:(\s|$)", stripped):
         return False
     # Drop RST section underlines (e.g. "====", "----", "~~~~")
     if _RST_UNDERLINE_RE.match(stripped):
@@ -165,6 +186,7 @@ def generate_combined_markdown(app, exception):
         relative = doc_file.relative_to(docs_root)
         in_backtick_fence = False
         in_rst_code_block = False
+        in_rst_skip_block = False
         kept = []
         for line in lines:
             stripped = line.strip()
@@ -176,12 +198,21 @@ def generate_combined_markdown(app, exception):
             if in_backtick_fence:
                 kept.append(line)
                 continue
+            # RST skip block (e.g. .. raw::): discard all indented content
+            if in_rst_skip_block:
+                if not stripped or line[0] in (" ", "\t"):
+                    continue
+                in_rst_skip_block = False
             # RST code block: exit when a non-blank, non-indented line appears
             if in_rst_code_block:
                 if not stripped or line[0] in (" ", "\t"):
                     kept.append(line)
                     continue
                 in_rst_code_block = False
+            # RST raw block: enter and discard both the directive and its body
+            if _RST_SKIP_BLOCK_RE.match(stripped):
+                in_rst_skip_block = True
+                continue
             # RST code block: enter on directive line (directive itself is dropped)
             if _RST_CODE_BLOCK_RE.match(stripped):
                 in_rst_code_block = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,6 +101,10 @@ _RST_SKIP_BLOCK_RE = re.compile(r"^\.\.\s+raw::")
 # URL schemes so that multi-line RST inline hyperlinks are preserved.
 _HTML_TAG_RE = re.compile(r"^<(?!https?://|ftp://|mailto:)[a-zA-Z/!]")
 
+# Matches trailing HTML close tags at the end of a prose line
+# (e.g. "Browse blogs.</p>", "See the guide.</li></ul>").
+_TRAILING_HTML_CLOSE_RE = re.compile(r"(</[a-zA-Z]+>)+\s*$")
+
 MIN_PROSE_LINES = 10
 
 
@@ -187,6 +191,8 @@ def generate_combined_markdown(app, exception):
         in_backtick_fence = False
         in_rst_code_block = False
         in_rst_skip_block = False
+        in_html_comment = False  # inside <!-- ... --> block
+        in_html_open_tag = False  # inside a multi-line HTML opening tag
         kept = []
         for line in lines:
             stripped = line.strip()
@@ -197,6 +203,11 @@ def generate_combined_markdown(app, exception):
                 continue
             if in_backtick_fence:
                 kept.append(line)
+                continue
+            # HTML comment block (<!-- ... -->): discard all content until -->
+            if in_html_comment:
+                if "-->" in stripped:
+                    in_html_comment = False
                 continue
             # RST skip block (e.g. .. raw::): discard all indented content
             if in_rst_skip_block:
@@ -217,8 +228,26 @@ def generate_combined_markdown(app, exception):
             if _RST_CODE_BLOCK_RE.match(stripped):
                 in_rst_code_block = True
                 continue
-            if not stripped or is_prose_line(line):
+            # HTML comment open (<!-- ... -->): discard opener and enter state
+            if stripped.startswith("<!--"):
+                if "-->" not in stripped:
+                    in_html_comment = True
+                continue
+            # Multi-line HTML opening tag: skip continuation lines until >
+            if in_html_open_tag:
+                if ">" in stripped:
+                    in_html_open_tag = False
+                continue
+            # Detect HTML opening tags that wrap across lines (no > on this line)
+            if _HTML_TAG_RE.match(stripped) and ">" not in stripped:
+                in_html_open_tag = True
+                continue
+            if not stripped:
                 kept.append(line)
+            elif is_prose_line(line):
+                # Strip trailing HTML close tags (e.g. "See the guide.</p>")
+                cleaned = _TRAILING_HTML_CLOSE_RE.sub("", line).rstrip()
+                kept.append(cleaned if cleaned.strip() else line)
         cleaned = "\n".join(kept)
 
         combined.append(f"\n\n---\n\n# {relative}\n")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,8 +1,7 @@
 """Configuration file for the Sphinx documentation builder."""
 import os
-from sphinx import addnodes
+import re
 from pathlib import Path
-import shutil
 
 external_projects_remote_repository = ""
 external_projects_current_project = "dcgpu"
@@ -46,16 +45,6 @@ html_css_files = ["index.css"]
 external_toc_path = "./sphinx/_toc.yml"
 
 exclude_patterns = ['.venv']
-
-EXCLUDED_DIRS = {
-    "_build",
-    "_templates",
-    "_static",
-    ".git",
-    ".venv",
-}
-
-import re
 
 EXCLUDED_DIRS = {
     "_build",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,8 +55,68 @@ EXCLUDED_DIRS = {
     ".venv",
 }
 
+import re
+
+EXCLUDED_DIRS = {
+    "_build",
+    "_templates",
+    "_static",
+    ".git",
+    ".venv",
+}
+
+MARKUP_PREFIXES = (
+    ":::",
+    "```{",
+    "```",
+    ":img-top:",
+    ":class",
+    ":link:",
+    ":link-type:",
+    ":shadow:",
+    ":columns:",
+    ":padding:",
+    ":gutter:",
+    ":open:",
+    ":name:",
+    ":header-rows:",
+    ":alt:",
+    "+++",
+    "<",
+    "-->",
+    "{bdg-",
+)
+
+# Matches lines like "align: center", "alt:", "name: foo" (directive options
+# not starting with a colon, common in MyST figure/table fences)
+_BARE_DIRECTIVE_RE = re.compile(r"^[a-z][a-z_-]*:\s*\S*$")
+
+# Matches MyST/RST anchor labels like "(gpu-arch-documentation)="
+_ANCHOR_LABEL_RE = re.compile(r"^\(\w[\w-]*\)=$")
+
+MIN_PROSE_LINES = 10
+
+
 def should_skip(path: Path) -> bool:
     return any(part in EXCLUDED_DIRS for part in path.parts)
+
+
+def is_prose_line(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped:
+        return False
+    if stripped.startswith(MARKUP_PREFIXES):
+        return False
+    # Drop bare directive-option lines (e.g. "align: center", "alt:")
+    if _BARE_DIRECTIVE_RE.match(stripped):
+        return False
+    # Drop MyST/RST anchor labels (e.g. "(gpu-arch-documentation)=")
+    if _ANCHOR_LABEL_RE.match(stripped):
+        return False
+    # Drop lines that contain an HTML tag anywhere (e.g. ".</p>")
+    if re.search(r"</?[a-zA-Z]", stripped):
+        return False
+    return True
 
 
 def generate_combined_markdown(app, exception):
@@ -70,9 +130,10 @@ def generate_combined_markdown(app, exception):
     combined = []
 
     if base_file.exists():
-        combined.append(base_file.read_text(encoding="utf-8"))
+        base_text = base_file.read_text(encoding="utf-8").rstrip().rstrip("-").rstrip()
+        combined.append(base_text)
     else:
-        combined.append("# AMD Instinct Data Center GPU Documentation\n")
+        combined.append("# AMD Instinct Data Center GPU Documentation")
 
     all_files = sorted(docs_root.rglob("*.md"))
 
@@ -83,21 +144,28 @@ def generate_combined_markdown(app, exception):
         if doc_file == base_file:
             continue
 
-        relative = doc_file.relative_to(docs_root)
-
-        combined.append(f"\n---\n")
-        combined.append(f"\n# {relative}\n")
-
         try:
             content = doc_file.read_text(encoding="utf-8")
-            combined.append(content)
-            combined.append("\n")
+        except Exception:
+            continue
 
-        except Exception as e:
-            combined.append(f"\n[ERROR reading file: {e}]\n")
+        lines = content.splitlines()
+        prose_lines = [line for line in lines if is_prose_line(line)]
+
+        if len(prose_lines) < MIN_PROSE_LINES:
+            continue
+
+        relative = doc_file.relative_to(docs_root)
+        cleaned = "\n".join(
+            line for line in lines
+            if line.strip() == "" or is_prose_line(line)
+        )
+
+        combined.append(f"\n\n---\n\n# {relative}\n")
+        combined.append(cleaned.strip())
 
     output_file.write_text(
-        "\n".join(combined),
+        "\n".join(combined) + "\n",
         encoding="utf-8",
     )
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -88,6 +88,9 @@ _ANCHOR_LABEL_RE = re.compile(r"^\(\w[\w-]*\)=$")
 # Matches RST section underlines (e.g. "====", "----", "~~~~")
 _RST_UNDERLINE_RE = re.compile(r"^[=\-~^\"\'#*+]{3,}$")
 
+# Matches RST code block directives (e.g. ".. code-block:: cpp", ".. code:: sh")
+_RST_CODE_BLOCK_RE = re.compile(r"^\.\.\s+(code-block|code|sourcecode)::")
+
 MIN_PROSE_LINES = 10
 
 
@@ -107,14 +110,13 @@ def is_prose_line(line: str) -> bool:
     # Drop MyST/RST anchor labels (e.g. "(gpu-arch-documentation)=")
     if _ANCHOR_LABEL_RE.match(stripped):
         return False
-    # Drop lines that contain an HTML tag anywhere (e.g. ".</p>")
-    if re.search(r"</?[a-zA-Z]", stripped):
-        return False
     # Drop RST directives, comments, hyperlink targets, and substitution definitions
     if stripped.startswith(".."):
         return False
-    # Drop RST field list items (e.g. ":type: int") and MyST directive options not in MARKUP_PREFIXES
-    if re.match(r"^:[A-Za-z]", stripped):
+    # Drop RST field list items (e.g. ":type: int") and MyST directive options without
+    # a leading colon (e.g. "align: center"). Excludes inline roles at line start
+    # (e.g. ":cpp:func:`hipMalloc` returns..." or ":ref:`foo <bar>` describes...").
+    if re.match(r"^:[A-Za-z][A-Za-z0-9_-]*:(\s|$)", stripped):
         return False
     # Drop RST section underlines (e.g. "====", "----", "~~~~")
     if _RST_UNDERLINE_RE.match(stripped):
@@ -161,15 +163,30 @@ def generate_combined_markdown(app, exception):
             continue
 
         relative = doc_file.relative_to(docs_root)
-        in_code_block = False
+        in_backtick_fence = False
+        in_rst_code_block = False
         kept = []
         for line in lines:
-            if line.strip().startswith("```"):
-                in_code_block = not in_code_block
+            stripped = line.strip()
+            # Backtick fences (MyST/Markdown)
+            if stripped.startswith("```"):
+                in_backtick_fence = not in_backtick_fence
                 kept.append(line)
-            elif in_code_block:
+                continue
+            if in_backtick_fence:
                 kept.append(line)
-            elif line.strip() == "" or is_prose_line(line):
+                continue
+            # RST code block: exit when a non-blank, non-indented line appears
+            if in_rst_code_block:
+                if not stripped or line[0] in (" ", "\t"):
+                    kept.append(line)
+                    continue
+                in_rst_code_block = False
+            # RST code block: enter on directive line (directive itself is dropped)
+            if _RST_CODE_BLOCK_RE.match(stripped):
+                in_rst_code_block = True
+                continue
+            if not stripped or is_prose_line(line):
                 kept.append(line)
         cleaned = "\n".join(kept)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,19 +64,23 @@ def generate_combined_markdown(app, exception):
         return
 
     docs_root = Path(app.srcdir)
-
     output_file = Path(app.outdir) / "llms.txt"
+    base_file = docs_root / "llms.txt"
 
-    print(output_file)
+    combined = []
+
+    if base_file.exists():
+        combined.append(base_file.read_text(encoding="utf-8"))
+    else:
+        combined.append("# AMD Instinct Data Center GPU Documentation\n")
 
     all_files = sorted(docs_root.rglob("*.md"))
 
-    combined = []
-    combined.append("# Combined Documentation\n")
-
     for doc_file in all_files:
-
         if should_skip(doc_file):
+            continue
+
+        if doc_file == base_file:
             continue
 
         relative = doc_file.relative_to(docs_root)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,6 +46,8 @@ external_toc_path = "./sphinx/_toc.yml"
 
 exclude_patterns = ['.venv']
 
+html_extra_path = ["llms.txt"]
+
 EXCLUDED_DIRS = {
     "_build",
     "_templates",
@@ -83,6 +85,9 @@ _BARE_DIRECTIVE_RE = re.compile(r"^[a-z][a-z_-]*:\s*\S*$")
 # Matches MyST/RST anchor labels like "(gpu-arch-documentation)="
 _ANCHOR_LABEL_RE = re.compile(r"^\(\w[\w-]*\)=$")
 
+# Matches RST section underlines (e.g. "====", "----", "~~~~")
+_RST_UNDERLINE_RE = re.compile(r"^[=\-~^\"\'#*+]{3,}$")
+
 MIN_PROSE_LINES = 10
 
 
@@ -105,6 +110,15 @@ def is_prose_line(line: str) -> bool:
     # Drop lines that contain an HTML tag anywhere (e.g. ".</p>")
     if re.search(r"</?[a-zA-Z]", stripped):
         return False
+    # Drop RST directives, comments, hyperlink targets, and substitution definitions
+    if stripped.startswith(".."):
+        return False
+    # Drop RST field list items (e.g. ":type: int") and MyST directive options not in MARKUP_PREFIXES
+    if re.match(r"^:[A-Za-z]", stripped):
+        return False
+    # Drop RST section underlines (e.g. "====", "----", "~~~~")
+    if _RST_UNDERLINE_RE.match(stripped):
+        return False
     return True
 
 
@@ -113,7 +127,7 @@ def generate_combined_markdown(app, exception):
         return
 
     docs_root = Path(app.srcdir)
-    output_file = Path(app.outdir) / "llms.txt"
+    output_file = Path(app.outdir) / "llms-full.txt"
     base_file = docs_root / "llms.txt"
 
     combined = []
@@ -124,7 +138,9 @@ def generate_combined_markdown(app, exception):
     else:
         combined.append("# AMD Instinct Data Center GPU Documentation")
 
-    all_files = sorted(docs_root.rglob("*.md"))
+    all_files = sorted(
+        list(docs_root.rglob("*.md")) + list(docs_root.rglob("*.rst"))
+    )
 
     for doc_file in all_files:
         if should_skip(doc_file):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -161,10 +161,17 @@ def generate_combined_markdown(app, exception):
             continue
 
         relative = doc_file.relative_to(docs_root)
-        cleaned = "\n".join(
-            line for line in lines
-            if line.strip() == "" or is_prose_line(line)
-        )
+        in_code_block = False
+        kept = []
+        for line in lines:
+            if line.strip().startswith("```"):
+                in_code_block = not in_code_block
+                kept.append(line)
+            elif in_code_block:
+                kept.append(line)
+            elif line.strip() == "" or is_prose_line(line):
+                kept.append(line)
+        cleaned = "\n".join(kept)
 
         combined.append(f"\n\n---\n\n# {relative}\n")
         combined.append(cleaned.strip())

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -247,7 +247,15 @@ def generate_combined_markdown(app, exception):
             elif is_prose_line(line):
                 # Strip trailing HTML close tags (e.g. "See the guide.</p>")
                 cleaned = _TRAILING_HTML_CLOSE_RE.sub("", line).rstrip()
-                kept.append(cleaned if cleaned.strip() else line)
+                cleaned_stripped = cleaned.strip()
+                if not cleaned_stripped:
+                    # Entire line was HTML close tags — keep original (shouldn't
+                    # normally reach here since _is_prose_line filters HTML).
+                    kept.append(line)
+                elif re.search(r"\w", cleaned_stripped):
+                    # Line has real word content after stripping close tags.
+                    kept.append(cleaned)
+                # else: only punctuation remains (e.g. bare ".") — discard.
         cleaned = "\n".join(kept)
 
         combined.append(f"\n\n---\n\n# {relative}\n")

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,83 @@
+# AMD Instinct Data Center GPU Documentation
+
+> Comprehensive guides and technical documentation for deploying AMD Instinct Data Center GPUs in enterprise environments. Covers system administration, cluster management, monitoring, and operational best practices for HPC and AI workloads. For API documentation and the ROCm software stack, see https://rocm.docs.amd.com.
+
+## GPU architecture
+
+- [AMD Instinct GPU architecture overview](https://instinct.docs.amd.com/en/latest/gpu-arch/gpu-arch.html): Microarchitecture overview of AMD Instinct MI350, MI300, MI250, and MI100 GPU accelerators.
+- [AMD Instinct MI350](https://instinct.docs.amd.com/en/latest/gpu-arch/mi350.html): Architecture and specifications for the MI350 series.
+- [AMD Instinct MI300](https://instinct.docs.amd.com/en/latest/gpu-arch/mi300.html): Architecture and specifications for the MI300 series, including MI300X and MI300A.
+- [AMD Instinct MI250](https://instinct.docs.amd.com/en/latest/gpu-arch/mi250.html): Architecture and specifications for the MI250 series.
+- [AMD Instinct MI100](https://instinct.docs.amd.com/en/latest/gpu-arch/mi100.html): Architecture and specifications for the MI100 series.
+
+## System administration
+
+### Bare metal
+
+- [Instinct GPU Driver](https://instinct.docs.amd.com/projects/amdgpu-docs/en/latest/): Install and configure the AMD GPU driver. Covers logging and error codes.
+- [Instinct Customer Acceptance Guide](https://instinct.docs.amd.com/projects/system-acceptance/en/latest/): Configure, validate, benchmark, and baseline AMD Instinct GPUs.
+- [AMD SMI](https://rocm.docs.amd.com/projects/amdsmi/en/latest/): System management interface for monitoring and managing AMD GPUs.
+- [ROCm Validation Suite](https://rocm.docs.amd.com/projects/ROCmValidationSuite/en/latest/): System validation and diagnostics.
+- [Cluster Validation Suite](https://rocm.docs.amd.com/projects/cvs/en/latest/): Test scripts to validate AMD AI clusters.
+
+### Containers and orchestration
+
+- [AMD GPU Operator](https://instinct.docs.amd.com/projects/gpu-operator/en/latest/): Deploy and manage AMD Instinct GPUs within Kubernetes clusters.
+- [Network Operator](https://instinct.docs.amd.com/projects/network-operator/en/main/): Use AMD AINICs in Kubernetes environments.
+- [Kubernetes Device Plugin](https://instinct.docs.amd.com/projects/k8s-device-plugin/en/latest/): Register AMD GPUs to Kubernetes container clusters.
+- [Device Metrics Exporter](https://instinct.docs.amd.com/projects/device-metrics-exporter/en/latest/): Prometheus-format GPU metrics collection.
+- [AMD Container Toolkit](https://instinct.docs.amd.com/projects/container-toolkit/en/latest/): Integrate AMD Instinct GPUs with Docker.
+
+### Cluster management
+
+- [Cluster Networking](https://instinct.docs.amd.com/projects/gpu-cluster-networking/en/latest/): Optimize networking for Instinct GPU applications.
+
+### Cloud
+
+- [Instinct on Azure](https://instinct.docs.amd.com/projects/instinct-azure/latest/): Get started with AMD Instinct on Microsoft Azure.
+
+### Virtualization
+
+- [Instinct Virtualization Driver](https://instinct.docs.amd.com/projects/virt-drv/en/latest/): Virtualization driver for AMD Instinct GPUs.
+- [AMD SMI for Virtualization](https://instinct.docs.amd.com/projects/amd-smi-virt/en/latest/): Manage and monitor AMD virtualization-enabled GPUs.
+
+## Workloads
+
+### Computer vision
+
+- [Models and applications](https://instinct.docs.amd.com/en/latest/vision/ai.html): Design, train, and infer computer vision models on AMD Instinct GPUs.
+- [Image and video decoding](https://instinct.docs.amd.com/en/latest/vision/decode.html): Decode image and video formats using AMD Instinct GPUs.
+- [Image processing](https://instinct.docs.amd.com/en/latest/vision/preprocess.html): Eliminate image preprocessing bottlenecks with AMD Instinct GPUs.
+
+### Data science
+
+- [ROCm Data Science Toolkit (ROCm-DS)](https://instinct.docs.amd.com/en/latest/data-science/index.html): Accelerate data science workloads on AMD Instinct GPUs.
+- [hipDF](https://instinct.docs.amd.com/en/latest/data-science/hipDF.html): GPU-accelerated DataFrames for data manipulation and analysis.
+- [hipGRAPH](https://instinct.docs.amd.com/en/latest/data-science/hipGRAPH.html): Create and analyze graphs and complex networks on AMD Instinct GPUs.
+- [hipVS](https://instinct.docs.amd.com/en/latest/data-science/hipVS.html): Vector search operations on AMD Instinct GPUs.
+- [hipMM](https://instinct.docs.amd.com/en/latest/data-science/hipMM.html): Advanced memory management for ROCm-DS libraries.
+- [hipRAFT](https://instinct.docs.amd.com/en/latest/data-science/hipRAFT.html): Fundamental algorithms and primitives for ROCm-DS libraries.
+
+### Life science
+
+- [ROCm Toolkit for Life Science (ROCm-LS)](https://instinct.docs.amd.com/en/latest/life-science/index.html): Accelerate life science workloads on AMD Instinct GPUs.
+- [hipCIM](https://instinct.docs.amd.com/en/latest/life-science/hipCIM.html): N-dimensional image processing for medical imaging on AMD Instinct GPUs.
+- [MONAI](https://instinct.docs.amd.com/en/latest/life-science/MONAI.html): Train and deploy AI models for medical imaging on AMD Instinct GPUs.
+
+## ISV applications
+
+- [Ansys Fluent](https://instinct.docs.amd.com/en/latest/isv-apps/ansys-fluent.html): Computational fluid dynamics with AMD GPU acceleration.
+- [Ansys Mechanical](https://instinct.docs.amd.com/en/latest/isv-apps/ansys-mechanical.html): Structural simulation on AMD Instinct GPUs.
+- [Cadence Fidelity LES Solver](https://instinct.docs.amd.com/en/latest/isv-apps/cadence-fidelity.html): Computational fluid dynamics on AMD Instinct GPUs.
+- [Devito Codes DevitoPRO](https://instinct.docs.amd.com/en/latest/isv-apps/devito.html): Seismic imaging on AMD Instinct GPUs.
+- [Siemens Simcenter STAR-CCM+](https://instinct.docs.amd.com/en/latest/isv-apps/siemens.html): Multiphysics CFD simulation on AMD Instinct GPUs.
+- [Stone Ridge Technology ECHELON](https://instinct.docs.amd.com/en/latest/isv-apps/stone-ridge.html): Reservoir simulation on AMD Instinct GPUs.
+- [GSplat](https://instinct.docs.amd.com/en/latest/simulation/gsplat.html): Gaussian splatting on AMD Instinct MI300X.
+
+## Programming reference
+
+- [HIP C++](https://rocm.docs.amd.com/projects/HIP/en/latest/): HIP programming model and API for AMD GPUs.
+- [OpenMP](https://rocm.docs.amd.com/projects/llvm-project/en/latest/conceptual/openmp.html): OpenMP programming model for AMD GPUs.
+- [AMD SMI API](https://rocm.docs.amd.com/projects/amdsmi/en/latest/): Full AMD SMI API reference.
+
+---

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -14,8 +14,8 @@
 
 ### Bare metal
 
-- [Instinct GPU Driver](https://instinct.docs.amd.com/projects/amdgpu-docs/en/latest/): Install and configure the AMD GPU driver. Covers logging and error codes.
-- [Instinct Customer Acceptance Guide](https://instinct.docs.amd.com/projects/system-acceptance/en/latest/): Configure, validate, benchmark, and baseline AMD Instinct GPUs.
+- [AMD GPU Driver (amdgpu)](https://instinct.docs.amd.com/projects/amdgpu-docs/en/latest/): Install and configure the AMD GPU driver. Covers logging and error codes.
+- [AMD Instinct Customer Acceptance Guide](https://instinct.docs.amd.com/projects/system-acceptance/en/latest/): Configure, validate, benchmark, and baseline AMD Instinct GPUs.
 - [AMD SMI](https://rocm.docs.amd.com/projects/amdsmi/en/latest/): System management interface for monitoring and managing AMD GPUs.
 - [ROCm Validation Suite](https://rocm.docs.amd.com/projects/ROCmValidationSuite/en/latest/): System validation and diagnostics.
 - [Cluster Validation Suite](https://rocm.docs.amd.com/projects/cvs/en/latest/): Test scripts to validate AMD AI clusters.
@@ -34,11 +34,11 @@
 
 ### Cloud
 
-- [Instinct on Azure](https://instinct.docs.amd.com/projects/instinct-azure/latest/): Get started with AMD Instinct on Microsoft Azure.
+- [AMD Instinct GPUs on Azure](https://instinct.docs.amd.com/projects/instinct-azure/latest/): Get started with AMD Instinct on Microsoft Azure.
 
 ### Virtualization
 
-- [Instinct Virtualization Driver](https://instinct.docs.amd.com/projects/virt-drv/en/latest/): Virtualization driver for AMD Instinct GPUs.
+- [AMD Instinct Virtualization Driver](https://instinct.docs.amd.com/projects/virt-drv/en/latest/): Virtualization driver for AMD Instinct GPUs.
 - [AMD SMI for Virtualization](https://instinct.docs.amd.com/projects/amd-smi-virt/en/latest/): Manage and monitor AMD virtualization-enabled GPUs.
 
 ## Workloads


### PR DESCRIPTION
## Motivation

AI coding assistants and agents increasingly need documentation in machine-readable formats. Two patterns are emerging as standards: per-page Markdown download (so users and agents can copy page content directly into an AI context window) and llms.txt (a combined documentation file that AI agents can discover and ingest). This PR adds both capabilities to make the documentation more accessible to AI-assisted workflows.

## Technical Details

Three changes to docs/conf.py, plus a new docs/llms.txt:

### Enable the theme download button

Sets "use_download_button": True in html_theme_options, which activates the built-in per-page download action provided by the Sphinx book theme. This allows readers to download the current page as Markdown or RST depending on the source format.

### Add a curated llms.txt index

Adds a base docs/llms.txt that serves as a curated index of all documentation pages, including those sourced from RST. Sets html_extra_path = ["llms.txt"] so Sphinx copies it to the output root, making it discoverable at /llms.txt.

### Add llms-full.txt generation

Adds a Sphinx build-finished hook (generate_combined_markdown) that filters and combines Markdown and RST source files into llms-full.txt. Each file is filtered through a prose detection pass that strips code fences, directive options, MyST/RST anchors, and inline HTML. Files with fewer than 10 prose lines are skipped entirely to avoid including navigation-only or boilerplate pages. Files in build, static, template, and VCS directories are excluded.

This follows the https://llmstxt.org/ for AI agent documentation discovery, and is compatible with https://docs.readthedocs.com/platform/stable/reference/llms-txt.html.

## Test Plan

- Verify the download button appears on documentation pages
- Verify llms.txt is available at {project_url}/llms.txt and contains only the curated index
- Verify llms-full.txt is available at {project_url}/llms-full.txt
- Confirm the curated index section appears at the top of llms-full.txt
- Confirm excluded directories (.git, _build, _static, _templates, .venv) are not represented in llms-full.txt
- Confirm navigation-only pages do not appear in the stitched output

## Test Result

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.